### PR TITLE
Add makefile for building zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ _testmain.go
 *.test
 *.prof
 .DS_Store
+
+*.zip

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+SLACK_URL ?= ""
+
+PHONY: build
+SILENT: build
+
+DEFAULT: build
+
+clean:
+	rm -rf sonitus.zip
+
+build: clean
+	echo "=> Building binary and creating zip"
+	$(eval TMP:=$(shell mktemp -d -t sonitus))
+	curl -L -o ${TMP}/lambda https://github.com/BBC-News/sonitus/releases/download/0.1.0/lambda
+	sed "s/##SLACK_URL##/${SLACK_URL}/" index.js > ${TMP}/index.js
+	zip sonitus.zip ${TMP}/*

--- a/README.md
+++ b/README.md
@@ -4,10 +4,16 @@ Sonitus
 Sontius is a AWS Lambda project to send alert messages to various chat services such as Slack.  This is achieved by using Go to process the SNS message and send a formatted message on another service.  The main application is written in Go as I wanted to learn some more Go and not JavaScript.
 
 ## Usage
-Edit the index.js file to include your Slack URL, then Zip up the binary and index.js and upload to Lambda.  From there, subscribe your Alarms to a topic and add a Lambda subscription to that topic.
+
+Run the build command then upload `sonitus.zip` into your Lambda function. From there, subscribe your Alarms to a topic and add a Lambda subscription to that topic.
 
 ## Building
-As this is designed for AWS, we will be targeting the Linux platform.  There is a pre build binary available, or you can build yourself, I recommend [gox](https://github.com/mitchellh/gox).
+
+To build with the latest realase of the prebuilt binary run the following:
+
+`make -e SLACK_URL=http://www.my-slack-url.com`
+
+If you'd like to build the binary yourself, I'd recommend [gox](https://github.com/mitchellh/gox).
 
 ## Development
 To replicate Lambda, there is a debug folder with a example Alarm message from SNS.  Build a local binary and put the path to that binary into index.js instead of `/var/task/lambda`.  Simply run `node start.js` and it will send a message.

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ exports.handler = function(event, context) {
     var payload = JSON.stringify(event.Records[0])
     var sqs = "'" + payload + "'"
     // Ensure you leave a space after the URL
-    exec('/var/task/lambda ' + "SLACKURL " + sqs, function (error, stdout, stderr) {
+    exec('/var/task/lambda ' + "##SLACK_URL## " + sqs, function (error, stdout, stderr) {
     console.log('stderr:', stderr);
     console.log('stdout: ' + stdout);
     context.done(null, stdout);


### PR DESCRIPTION
![knock_knock](https://cloud.githubusercontent.com/assets/527874/8705271/7a3d6eb6-2b20-11e5-8fcc-5914e0fcf0e7.gif)

### Problem

You have to create the zip yourself and manually change the `SLACK_URL`.

### Solution

Adds a `Makefile` that builds the zip from the latest binary and the `SLACK_URL` env var passed in:

```bash
$: make -e SLACK_URL=https://www.slack.com/
```